### PR TITLE
 Update manifest, .env changes and fix client port

### DIFF
--- a/video-stream/client/client.lua
+++ b/video-stream/client/client.lua
@@ -1,15 +1,11 @@
-local endpoint = SplitHostPort(GetCurrentServerEndpoint())
-
--- use client connecting endpoint
-local streamURL = string.format("http://%s:3000/dui/index.html", endpoint)
-local streamOfflineURL = string.format("http://%s:3000/dui/off.html", endpoint)
-
 RegisterCommand('video-stream', function (source, arg, rawInput)
 	SetEntityCoords(PlayerPedId(), 320.217, 263.81, 82.974)
 	SetEntityHeading(PlayerPedId(), 180.0)
 end)
 
 -------------------
+
+local streamOfflineURL <const> = string.format("nui://%s/public/dui/off.html", GetCurrentResourceName())
 
 local scale = 1.5
 local screenWidth = math.floor(1280 / scale)
@@ -57,6 +53,12 @@ CreateThread(function ()
 
 	-- Give time for resource to start
 	Wait(3500)
+
+	-- Gather the stream url
+	local endpoint = SplitHostPort(GetCurrentServerEndpoint())
+
+	local port = GetConvarInt("video_stream_port", 3000)
+	local streamURL = string.format("http://%s:%d/dui/index.html", endpoint, port)
 
 	-- Check stream status
 	TriggerServerEvent('video-stream:status')

--- a/video-stream/fxmanifest.lua
+++ b/video-stream/fxmanifest.lua
@@ -12,3 +12,5 @@ client_scripts {
 server_scripts {
 	'server.js'
 }
+
+file "public/dui/off.html"

--- a/video-stream/fxmanifest.lua
+++ b/video-stream/fxmanifest.lua
@@ -1,6 +1,8 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
+fx_version "cerulean"
+game "gta5"
 
 dependency 'yarn'
+lua54 "yes"
 
 client_scripts {
 	'client/utils.lua',

--- a/video-stream/server.js
+++ b/video-stream/server.js
@@ -1,22 +1,25 @@
 const path = require('path')
+const fs = require('fs')
+const dotenv = require('dotenv')
+
 const resourcePath = global.GetResourcePath?
 	global.GetResourcePath(global.GetCurrentResourceName()) : global.__dirname
 
-require('dotenv').config({ path: path.join(resourcePath, './.env') })
+const config = dotenv.parse(fs.readFileSync(path.join(resourcePath, '.env')))
 
 const http = require('http')
 const WebSocket = require('ws')
 const finalhandler = require('finalhandler')
 const serveStatic = require('serve-static')
 const { spawn } = require('child_process')
-const ffmpegPath = process.env.FFMPEG_PATH || require('ffmpeg-static')
+const ffmpegPath = config.FFMPEG_PATH || require('ffmpeg-static')
 const NodeMediaServer = require('node-media-server')
 
-const RTMP_ENABLED = process.env.RTMP_ENABLED || 0
-const RTMP_PORT = process.env.RTMP_PORT || 1935
-const RTMP_SECRET = process.env.RTMP_SECRET || 'secret'
-const PORT = process.env.PORT || 3000
-const STREAM_PATH = process.env.STREAM_PATH ||
+const RTMP_ENABLED = config.RTMP_ENABLED || 0
+const RTMP_PORT = config.RTMP_PORT || 1935
+const RTMP_SECRET = config.RTMP_SECRET || 'secret'
+const PORT = config.PORT || 3000
+const STREAM_PATH = config.STREAM_PATH ||
 	`rtmp://localhost:${RTMP_PORT}/live/STREAM_NAME`
 
 let streamProc
@@ -195,4 +198,6 @@ if (global.RegisterCommand) {
 			onPostPublish(streamProc)
 		}
 	}, true)
+
+	SetConvarReplicated("video_stream_port", config.PORT)
 }


### PR DESCRIPTION
- Updated __resource.lua to fxmanifest.lua, __resource.lua has been deprecated for some time
- .env variables are no longer loaded into the entire process, that should prevent conflicts with other resources using process.env
- client now uses the port set in .env, this works by using replicated convar

To achieve the last I have changed the offline url from url:port/offline.html to nui://resource/public/dui/offline.html so it works without knowing the port

Also enabled Lua 5.4 for the giggles

Tested on FXServer 5053 and canary client